### PR TITLE
Fixed addGNSS_6 function prototype

### DIFF
--- a/RUI3-RAK12500-RAK1904-GNSS/RUI3-RAK12500-RAK1904-GNSS.ino
+++ b/RUI3-RAK12500-RAK1904-GNSS/RUI3-RAK12500-RAK1904-GNSS.ino
@@ -187,7 +187,7 @@ void setup()
 	// Delay for 5 seconds to give the chance for AT+BOOT
 	delay(5000);
 
-	api.system.firmwareVersion.set("RUI3-Location-Tracker-V1.0.0");
+	api.system.firmwareVersion.set("1.0.1-rc1");
 
 	Serial.println("RAKwireless RUI3 Location Tracker");
 	Serial.println("------------------------------------------------------");

--- a/RUI3-RAK12500-RAK1904-GNSS/wisblock_cayenne.cpp
+++ b/RUI3-RAK12500-RAK1904-GNSS/wisblock_cayenne.cpp
@@ -75,7 +75,7 @@ uint8_t WisCayenne::addGNSS_4(uint8_t channel, uint32_t latitude, uint32_t longi
  * @param altitude Altitude as read from the GNSS receiver
  * @return uint8_t bytes added to the data packet
  */
-uint8_t WisCayenne::addGNSS_6(uint8_t channel, uint32_t latitude, uint32_t longitude, uint32_t altitude)
+uint8_t WisCayenne::addGNSS_6(uint8_t channel, int32_t latitude, int32_t longitude, int32_t altitude)
 {
 	// check buffer overflow
 	if ((_cursor + LPP_GPS6_SIZE + 2) > _maxsize)

--- a/RUI3-RAK12500-RAK1904-GNSS/wisblock_cayenne.h
+++ b/RUI3-RAK12500-RAK1904-GNSS/wisblock_cayenne.h
@@ -33,7 +33,7 @@ public:
 	WisCayenne(uint8_t size) : CayenneLPP(size) {}
 
 	uint8_t addGNSS_4(uint8_t channel, uint32_t latitude, uint32_t longitude, uint32_t altitude);
-	uint8_t addGNSS_6(uint8_t channel, uint32_t latitude, uint32_t longitude, uint32_t altitude);
+	uint8_t addGNSS_6(uint8_t channel, int32_t latitude, int32_t longitude, int32_t altitude);
 	uint8_t addGNSS_H(uint32_t latitude, uint32_t longitude, uint16_t altitude, uint16_t accuracy, uint16_t battery);
 	uint8_t addGNSS_T(int32_t latitude, int32_t longitude, int16_t altitude, int16_t accuracy, int8_t sats);
 	uint8_t addVoc_index(uint8_t channel, uint32_t voc_index);


### PR DESCRIPTION
Changed the firmware version format into one compatible with the `https://semver.org/` org standard. Changed the prototype of the `addGNSS_6` method to allow for negative values being passed in.

Signed-off-by: Sidd Gupta (sidd.gupta@zylum.in)